### PR TITLE
Inspect template.json

### DIFF
--- a/foundryvtt-devMode.mjs
+++ b/foundryvtt-devMode.mjs
@@ -5,6 +5,7 @@ import { _devModeDisplayUsabilityErrors } from './module/patches/displayUsabilit
 import { libWrapper } from './module/shim.mjs';
 import setupDevModeAnchor from './module/hooks/dev-mode-anchor.mjs';
 import { setupJSONDiff } from './module/hooks/json-changes.mjs';
+import { inspectSystemTemplate } from './module/hooks/inspect-template.mjs';
 import setupDisableTemplateCache from './module/patches/getTemplate.mjs';
 
 Handlebars.registerHelper('dev-concat', (...args) => {
@@ -63,4 +64,6 @@ Hooks.on('ready', () => {
   }
 
   setupJSONDiff();
+
+  inspectSystemTemplate();
 });

--- a/lang/en.json
+++ b/lang/en.json
@@ -86,7 +86,7 @@
     "template-json-report": {
       "unregistered": {
         "Label": "Unregistered",
-        "Hint": "Template document types defined but not registered."
+        "Hint": "Template document types defined but lack registered sheet."
       },
       "untemplated": {
         "Label": "Untemplated",

--- a/lang/en.json
+++ b/lang/en.json
@@ -47,6 +47,10 @@
         "Name": "Module JSON changes",
         "Hint": "Notify about module.json changes on any and all active modules."
       },
+      "inspect-system-template": {
+        "Name": "Inspect template.json",
+        "Hint": "Does basic checks on template.json for potential issues on load."
+      },
       "dice": {
         "Name": "Dice"
       },
@@ -77,6 +81,24 @@
       },
       "time": {
         "Name": "Time"
+      }
+    },
+    "template-json-report": {
+      "unregistered": {
+        "Label": "Unregistered",
+        "Hint": "Template document types defined but not registered."
+      },
+      "untemplated": {
+        "Label": "Untemplated",
+        "Hint": "Registered document types not found in template."
+      },
+      "unused": {
+        "Label": "Unused",
+        "Hint": "Templates left unused."
+      },
+      "undefined": {
+        "Label": "Undefined",
+        "Hint": "Templates referred to in types but not defined."
       }
     },
     "LogLevels": {

--- a/module/classes/DevMode.mjs
+++ b/module/classes/DevMode.mjs
@@ -26,7 +26,8 @@ export class DevMode {
     showChatIds: 'show-chat-ids',
     disableTemplateCache: 'disable-template-cache',
     jsonDiffSystem: 'json-diff-system',
-    jsonDiffModules: 'json-diff-modules'
+    jsonDiffModules: 'json-diff-modules',
+    inspectTemplate: 'inspect-system-template'
   };
 
   static TEMPLATES = {

--- a/module/classes/DevModeSettings.mjs
+++ b/module/classes/DevModeSettings.mjs
@@ -56,6 +56,13 @@ export class DevModeSettings {
       onChange: (value) => {
         if (value) this.debouncedReload();
       }
+    },
+    {
+      key: DevMode.SETTINGS.inspectTemplate,
+      default: false,
+      onChange: (value) => {
+        if (value) this.debouncedReload();
+      }
     }
   ];
 

--- a/module/hooks/inspect-template.mjs
+++ b/module/hooks/inspect-template.mjs
@@ -28,16 +28,19 @@ export async function inspectSystemTemplate() {
     used: {}, // Templates that are used.
   };
 
-  for (const tt of templateTypes) {
-    // Fill reportData defaults
-    for (const rk of Object.keys(reportData)) {
-      reportData[rk][tt] = [];
-      reportData[rk]._total = 0;
+  // Fill reportData defaults
+  for (const category of Object.keys(reportData)) {
+      for (const type of templateTypes)
+        reportData[category][type] = new Set();
+      reportData[category]._total = 0;
+      reportData[category]._label = `DEV.template-json-report.${category}.Label`;
+      reportData[category]._hint = `DEV.template-json-report.${category}.Hint`;
     }
 
-    // Collect data
     const registeredSubtypes = game.system.entityTypes[tt]; // Registered types
     const templateData = template[tt]; // ex. Actor
+  // Collect and cross-reference data
+  for (const type of templateTypes) {
     const templateSubtypes = templateData.types; // ex. Actor.types
     for (const d of registeredSubtypes) {
       if (!templateSubtypes.includes(d))

--- a/module/hooks/inspect-template.mjs
+++ b/module/hooks/inspect-template.mjs
@@ -1,0 +1,109 @@
+import { DevMode } from '../classes/DevMode.mjs';
+
+/**
+ * Types that exist in the template.
+ */
+const templateTypes = ['Actor', 'Item'];
+/**
+ * Keys to ignore in the final report
+ */
+const ignoreReportKeys = ['used'];
+
+/**
+ * Unique array push.
+ */
+const uniquePush = (value, array) => {
+  if (!array.includes(value)) array.push(value);
+};
+
+export async function inspectSystemTemplate() {
+  if (!game.settings.get(DevMode.MODULE_ID, DevMode.SETTINGS.inspectTemplate)) return;
+
+  const template = game.system.template;
+  const reportData = {
+    unregistered: {}, // Templated types that lack registration
+    untemplated: {}, // Registered types that lack a template
+    unused: {}, // Templates that are defined but never used
+    undefined: {}, // Templates that are referred to but remain undefined
+    used: {}, // Templates that are used.
+  };
+
+  for (const tt of templateTypes) {
+    // Fill reportData defaults
+    for (const rk of Object.keys(reportData)) {
+      reportData[rk][tt] = [];
+      reportData[rk]._total = 0;
+    }
+
+    // Collect data
+    const registeredSubtypes = game.system.entityTypes[tt]; // Registered types
+    const templateData = template[tt]; // ex. Actor
+    const templateSubtypes = templateData.types; // ex. Actor.types
+    for (const d of registeredSubtypes) {
+      if (!templateSubtypes.includes(d))
+        uniquePush(d, reportData.untemplated[tt]);
+    }
+    for (const d of templateSubtypes) {
+      if (!registeredSubtypes.includes(d))
+        uniquePush(d, reportData.unregistered[tt]);
+
+      for (const ttt of templateData[d].templates) { // ex. Actor.type.templates.*
+        // Check for used or undefined templates
+        if (ttt in templateData.templates)
+          uniquePush(ttt, reportData.used[tt]);
+        else
+          uniquePush(ttt, reportData.undefined[tt]);
+      }
+    }
+
+    // Check for unused templates
+    for (const ttd2 of Object.keys(templateData.templates)) {
+      if (!reportData.used[tt].includes(ttd2))
+        uniquePush(ttd2, reportData.unused[tt]);
+    }
+  }
+
+  // Print report
+  console.group('template.json report');
+  for (const tt of templateTypes) {
+    console.group(tt);
+    for (const cat of Object.keys(reportData)) {
+      if (ignoreReportKeys.includes(cat)) continue;
+      const rd = reportData[cat][tt];
+      if (rd.length === 0) continue;
+      console.log(cat, ':', rd);
+    }
+
+    console.groupEnd();
+  }
+  console.groupEnd();
+
+  const problems = templateTypes
+    .reduce((total, tt) => {
+      const s = Object.keys(reportData)
+        .reduce((stotal, cat) => {
+          const ss = reportData[cat][tt].length;
+          reportData[cat]._total += ss;
+          return ss + stotal;
+        }, 0);
+      return s + total;
+
+    }, 0);
+
+  if (problems > 0) {
+    for (let ignore of ignoreReportKeys)
+      delete reportData[ignore];
+
+    new Dialog({
+      title: "template.json report",
+      content: await renderTemplate("modules/_dev-mode/templates/inspect-template-report.hbs", { data: reportData, types: templateTypes }),
+      buttons: {
+        dismiss: {
+          label: "Dismiss",
+          icon: '<i class="fas fa-power-off"></i>'
+        }
+      },
+      default: "dismiss"
+    }).render(true);
+  }
+}

--- a/module/hooks/inspect-template.mjs
+++ b/module/hooks/inspect-template.mjs
@@ -78,6 +78,9 @@ export async function inspectSystemTemplate() {
   }
   console.groupEnd();
 
+  for (let ignore of ignoreReportKeys)
+    delete reportData[ignore];
+
   const problems = templateTypes
     .reduce((total, tt) => {
       const s = Object.keys(reportData)
@@ -91,9 +94,6 @@ export async function inspectSystemTemplate() {
     }, 0);
 
   if (problems > 0) {
-    for (let ignore of ignoreReportKeys)
-      delete reportData[ignore];
-
     new Dialog({
       title: "template.json report",
       content: await renderTemplate("modules/_dev-mode/templates/inspect-template-report.hbs", { data: reportData, types: templateTypes }),

--- a/templates/inspect-template-report.hbs
+++ b/templates/inspect-template-report.hbs
@@ -7,18 +7,17 @@
   {{#each data as |tdata id|}}
   {{#if (gt tdata._total 0)}}
   <div class="form-group">
-    <h3>{{localize (concat (concat "DEV.template-json-report." id) ".Label")}}</h3>
-    <p class="notes">{{localize (concat (concat "DEV.template-json-report." id) ".Hint")}}</p>
-    {{log id tdata}}
+    <h3>{{localize _label}}</h3>
+    <p class="notes">{{localize _hint}}</p>
     <div class="form-fields">
-      {{#each tdata as |stdata typeId|}}
-      {{#unless (eq typeId "_total")}}
+      {{#each ../types as |type|}}
+      {{#with (lookup tdata type) as |stdata|}}
       <ul>
         {{#each stdata as |template|}}
         <li>{{template}}</li>
         {{/each}}
       </ul>
-      {{/unless}}
+      {{/with}}
       {{/each}}
     </div>
   </div>

--- a/templates/inspect-template-report.hbs
+++ b/templates/inspect-template-report.hbs
@@ -1,27 +1,20 @@
-<form autocomplete="off">
-  <div class="form-group">
-    {{#each types}}
-    <h2>{{this}}</h2>
+<div class="flexrow">
+  {{#each types}}<h2>{{this}}</h2>{{/each}}
+</div>
+{{#each data as |tdata id|}}
+{{#if (gt tdata._total 0)}}
+<div class="flexcol">
+  <h3 style="margin:0;padding:0;">{{localize _label}}</h3>
+  <p style="margin:0;padding:0;"><small>{{localize _hint}}</small></p>
+  <div class="flexrow">
+    {{#each ../types as |type|}}
+    {{#with (lookup tdata type) as |stdata|}}
+    <ul>
+      {{#each stdata as |template|}}<li>{{template}}</li>{{/each}}
+    </ul>
+    {{/with}}
     {{/each}}
   </div>
-  {{#each data as |tdata id|}}
-  {{#if (gt tdata._total 0)}}
-  <div class="form-group">
-    <h3>{{localize _label}}</h3>
-    <p class="notes">{{localize _hint}}</p>
-    <div class="form-fields">
-      {{#each ../types as |type|}}
-      {{#with (lookup tdata type) as |stdata|}}
-      <ul>
-        {{#each stdata as |template|}}
-        <li>{{template}}</li>
-        {{/each}}
-      </ul>
-      {{/with}}
-      {{/each}}
-    </div>
-  </div>
-  {{/if}}
-  {{/each}}
-  <hr>
-</form>
+</div>
+{{/if}}
+{{/each}}

--- a/templates/inspect-template-report.hbs
+++ b/templates/inspect-template-report.hbs
@@ -1,0 +1,28 @@
+<form autocomplete="off">
+  <div class="form-group">
+    {{#each types}}
+    <h2>{{this}}</h2>
+    {{/each}}
+  </div>
+  {{#each data as |tdata id|}}
+  {{#if (gt tdata._total 0)}}
+  <div class="form-group">
+    <h3>{{localize (concat (concat "DEV.template-json-report." id) ".Label")}}</h3>
+    <p class="notes">{{localize (concat (concat "DEV.template-json-report." id) ".Hint")}}</p>
+    {{log id tdata}}
+    <div class="form-fields">
+      {{#each tdata as |stdata typeId|}}
+      {{#unless (eq typeId "_total")}}
+      <ul>
+        {{#each stdata as |template|}}
+        <li>{{template}}</li>
+        {{/each}}
+      </ul>
+      {{/unless}}
+      {{/each}}
+    </div>
+  </div>
+  {{/if}}
+  {{/each}}
+  <hr>
+</form>


### PR DESCRIPTION
Adds simplistic template.json inspection and reporting by cross-referencing the data with itself for inconsistencies as well as making sure all the defined types are registered with Foundry.

Primarily this ends up detecting typos in template names, unused templates, and template references to non-existent ones.

![Screenshot 2021-10-25 223225](https://user-images.githubusercontent.com/8120158/138758457-25e48dcf-2926-4541-9135-519b3ba1de83.png)

Primarily this tries to inform you of bad template configuration, but it has some informative parts also.