### PR TITLE
Fix missing template handling

### DIFF
--- a/module/hooks/inspect-template.mjs
+++ b/module/hooks/inspect-template.mjs
@@ -45,7 +45,13 @@ export async function inspectSystemTemplate() {
       if (Object.keys(CONFIG[type].sheetClasses[templateSubtype] ?? {}).length === 0)
         reportData.unregistered[type].add(templateSubtype);
 
-      templateData[templateSubtype].templates.forEach(includedSubTemplate => { // ex. Actor.type.templates.*
+      if (templateData[templateSubtype] === undefined) {
+        console.warn(type, "subtype", templateSubtype, "lacks definition");
+        reportData.untemplated[type].add(templateSubtype);
+        return;
+      }
+
+      templateData[templateSubtype].templates?.forEach(includedSubTemplate => { // ex. Actor.type.templates.*
         // Check for used or undefined templates
         if (includedSubTemplate in templateData.templates)
           reportData.used[type].add(includedSubTemplate);


### PR DESCRIPTION
Fixes errors from missing main templates, such as if you have Actor.types = ["pc", "boot"] but don't have Actor.boot

Also ignores errors with missing "templates" key as it is not required, just odd.