### PR TITLE
Make config resizable

### DIFF
--- a/module/classes/DevModeConfig.mjs
+++ b/module/classes/DevModeConfig.mjs
@@ -19,6 +19,7 @@ export class DevModeConfig extends FormApplication {
       ],
       title: game.i18n.localize(`${DevMode.MODULE_ABBREV}.configMenu.FormTitle`),
       width: 400,
+      resizable: true,
     };
   }
 


### PR DESCRIPTION
As more tabs get added, the header can look very crowded, so it's helpful to be able to resize the window.
Some more in depth changes to the CSS or a different default width could be considered as well.

![image](https://user-images.githubusercontent.com/82790112/173980794-86dbd9af-b745-448d-b482-2fd79f58019f.png)
