### PR TITLE
fix: breakage on v9 when resetting to defaults

### DIFF
--- a/module/classes/DevModeConfig.mjs
+++ b/module/classes/DevModeConfig.mjs
@@ -37,7 +37,7 @@ export class DevModeConfig extends FormApplication {
 
   get compatibilityWarnings() {
     const settings = game.settings.get(DevMode.MODULE_ID, DevMode.SETTINGS.compatibilityWarnings)
-    return isObjectEmpty(settings) ? CONFIG.compatibility : settings;
+    return isObjectEmpty(settings) ? CONFIG.compatibility ?? {} : settings;
   }
 
   get autoOpenDocuments() {


### PR DESCRIPTION
As reported by Kaelad in the League Discord server, this fix is necessary for the "Reset Defaults" button to not cause the module to break for users on v9.

The debugging conversation starts here: https://discord.com/channels/732325252788387980/754127569246355477/1007425934439239810