### PR TITLE
Fix template-cache patch in Foundry v10

### DIFF
--- a/module/patches/getTemplate.mjs
+++ b/module/patches/getTemplate.mjs
@@ -12,7 +12,7 @@ export default function setupDisableTemplateCache() {
    * is rendered.
    * AKA: Poor Man's Hot-Reload
    */
-  async function _devModeGetTemplate(path, id) {
+  async function _devModeGetTemplate(path, ...args) {
     // eslint-disable-next-line
     if (_templateCache.hasOwnProperty(path)) {
       DevMode.log(false, 'Deleting cached template: ', path);

--- a/module/patches/getTemplate.mjs
+++ b/module/patches/getTemplate.mjs
@@ -21,7 +21,7 @@ export default function setupDisableTemplateCache() {
       delete _templateCache[path];
     }
 
-    return _getTemplate(path, id);
+    return _getTemplate(path, ...args);
   }
 
   // eslint-disable-next-line

--- a/module/patches/getTemplate.mjs
+++ b/module/patches/getTemplate.mjs
@@ -12,7 +12,7 @@ export default function setupDisableTemplateCache() {
    * is rendered.
    * AKA: Poor Man's Hot-Reload
    */
-  async function _devModeGetTemplate(path) {
+  async function _devModeGetTemplate(path, id) {
     // eslint-disable-next-line
     if (_templateCache.hasOwnProperty(path)) {
       DevMode.log(false, 'Deleting cached template: ', path);
@@ -21,7 +21,7 @@ export default function setupDisableTemplateCache() {
       delete _templateCache[path];
     }
 
-    return _getTemplate(path);
+    return _getTemplate(path, id);
   }
 
   // eslint-disable-next-line


### PR DESCRIPTION
Fixes #52. v10's `getTemplate` takes an extra parameter, which wasn't being passed through the patch.